### PR TITLE
Configure filepath for SolARMarker2DSquaredBinaryOpencv in PipelineTest*

### DIFF
--- a/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTest_Mapping_Mono_conf.xml
+++ b/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTest_Mapping_Mono_conf.xml
@@ -404,6 +404,9 @@
 			<property name="minThreshold" type="int" value="-1"/>
 			<property name="maxThreshold" type="int" value="220"/>
 		</configure>
+		<configure component="SolARMarker2DSquaredBinaryOpencv">
+			<property name="filePath" type="string" value="../../data/data_hololens/fiducialMarkerA.yml" description="Path of the .yml file describing the fiducial marker."/>
+		</configure>
 		<configure component="SolARImageFilterBinaryOpencv">
 			<property name="min" type="int" value="-1" description="minimum threshold (-1 to automatically compute it on the global image"/>
 			<property name="max" type="int" value="255" description="maximum threshold"/>

--- a/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi_conf.xml
+++ b/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi_conf.xml
@@ -404,6 +404,9 @@
 			<property name="minThreshold" type="int" value="-1"/>
 			<property name="maxThreshold" type="int" value="220"/>
 		</configure>
+		<configure component="SolARMarker2DSquaredBinaryOpencv">
+			<property name="filePath" type="string" value="../../data/data_hololens/fiducialMarkerA.yml" description="Path of the .yml file describing the fiducial marker."/>
+		</configure>
 		<configure component="SolARImageFilterBinaryOpencv">
 			<property name="min" type="int" value="-1" description="minimum threshold (-1 to automatically compute it on the global image"/>
 			<property name="max" type="int" value="255" description="maximum threshold"/>


### PR DESCRIPTION
This lead to the following error message:
[error] [39232] [SolAR::MODULES::OPENCV::SolARMarker2DSquaredBinaryOpencv::loadMarker():50] Binary Marker file path has not been defined