### PR TITLE
Feat/organize maps output

### DIFF
--- a/MapExtension/SolARSample_Mapping_MapExtension_Mono/SolARSample_Mapping_MapExtension_Mono_conf.xml
+++ b/MapExtension/SolARSample_Mapping_MapExtension_Mono/SolARSample_Mapping_MapExtension_Mono_conf.xml
@@ -243,7 +243,7 @@
 		<configure component="SolARDeviceDataLoader">
 			<property name="calibrationFile" type="string" value="../../data/data_hololens/hololens_calibration.yml"/>
 			<property name="pathToData" type="string" value="../../data/data_hololens/loop_desktop_B"/>
-			<property name="delayTime" type="int" value="1"/>
+			<property name="delayTime" type="int" value="300"/>
 		</configure>
 		<configure component="SolARSLAMBootstrapper">
 			<property name="hasPose" type="int" value="1"/>

--- a/MapExtension/SolARSample_Mapping_MapExtension_Mono/main.cpp
+++ b/MapExtension/SolARSample_Mapping_MapExtension_Mono/main.cpp
@@ -400,7 +400,7 @@ int main(int argc, char *argv[])
 		}
 
 		// Save map extension
-		mapper->bindTo<xpcf::IConfigurable>()->getProperty("directory")->setStringValue("mapExtension");
+		mapper->bindTo<xpcf::IConfigurable>()->getProperty("directory")->setStringValue("output/extension-map");
 		mapper->saveToFile();
     }
 

--- a/MapFusion/SolARSample_Mapping_FloatingMapFusion_Mono/SolARSample_Mapping_FloatingMapFusion_Mono_conf.xml
+++ b/MapFusion/SolARSample_Mapping_FloatingMapFusion_Mono/SolARSample_Mapping_FloatingMapFusion_Mono_conf.xml
@@ -251,7 +251,7 @@
 			<property name="thresConfidence" type="float" value="0.25"/>
 		</configure>
 		<configure component="SolARMapper" name="fusionMapper">
-			<property name="directory" type="string" value="../../data/map_hololens/mapAB"/>
+			<property name="directory" type="string" value="output/fusion-floating-map"/>
 			<property name="identificationFileName" type="string" value="identification.bin"/>
 			<property name="coordinateFileName" type="string" value="coordinate.bin"/>
 			<property name="pointCloudManagerFileName" type="string" value="pointcloud.bin"/>

--- a/MapFusion/SolARSample_Mapping_LocalMapFusion_Mono/SolARSample_Mapping_LocalMapFusion_Mono_conf.xml
+++ b/MapFusion/SolARSample_Mapping_LocalMapFusion_Mono/SolARSample_Mapping_LocalMapFusion_Mono_conf.xml
@@ -247,7 +247,7 @@
 			<property name="thresConfidence" type="float" value="0.25"/>
 		</configure>
 		<configure component="SolARMapper" name="fusionMapper">
-			<property name="directory" type="string" value="../../data/map_hololens/mapAB"/>
+			<property name="directory" type="string" value="output/fusion-local-map/"/>
 			<property name="identificationFileName" type="string" value="identification.bin"/>
 			<property name="coordinateFileName" type="string" value="coordinate.bin"/>
 			<property name="pointCloudManagerFileName" type="string" value="pointcloud.bin"/>

--- a/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTestMappingMono_main.cpp
+++ b/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTestMappingMono_main.cpp
@@ -122,6 +122,13 @@ int main(int argc, char ** argv)
 				(g3DViewer->display(pointCloud, keyframePoses[keyframePoses.size() - 1], keyframePoses) == FrameworkReturnCode::_STOP))
 				break;
 		}
+
+		std::vector<SRef<CloudPoint>> pointCloud;
+		std::vector<Transform3Df> keyframePoses;
+		gMappingPipeline->getDataForVisualization(pointCloud, keyframePoses);
+		LOG_INFO("Number of cloud points: {}", pointCloud.size());
+		LOG_INFO("Number of keyframes: {}", keyframePoses.size());
+
 		gMappingPipeline->stop();
     }
     catch (xpcf::Exception & e) {

--- a/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTest_Mapping_Mono_conf.xml
+++ b/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTest_Mapping_Mono_conf.xml
@@ -278,7 +278,7 @@
 			<property name="minTrackedPoints" type="int" value="200"/>
 		</configure>
 		<configure component="SolARMapper">
-			<property name="directory" type="string" value="mapA"/>
+			<property name="directory" type="string" value="output/pipelinetest-mono-map"/>
 			<property name="identificationFileName" type="string" value="identification.bin"/>
 			<property name="coordinateFileName" type="string" value="coordinate.bin"/>
 			<property name="pointCloudManagerFileName" type="string" value="pointcloud.bin"/>

--- a/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTest_Mapping_Mono_conf.xml
+++ b/Mapping/SolARPipeline_Mapping_Mono/tests/SolARPipelineTest_Mapping_Mono/SolARPipelineTest_Mapping_Mono_conf.xml
@@ -252,7 +252,7 @@
 		<configure component="SolARDeviceDataLoader">
 			<property name="calibrationFile" type="string" value="../../data/data_hololens/hololens_calibration.yml"/>
 			<property name="pathToData" type="string" value="../../data/data_hololens/loop_desktop_A"/>
-			<property name="delayTime" type="int" value="500"/>
+			<property name="delayTime" type="int" value="300"/>
 		</configure>
 		<configure component="SolARImageViewerOpencv">
 			<property name="title" type="string" value="AR device mapping. Green = inliers, Red = outliers"/>

--- a/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTestMappingMulti_main.cpp
+++ b/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTestMappingMulti_main.cpp
@@ -121,6 +121,13 @@ int main(int argc, char ** argv)
 				(g3DViewer->display(pointCloud, keyframePoses[keyframePoses.size() - 1], keyframePoses) == FrameworkReturnCode::_STOP))
 				break;
 		}
+
+		std::vector<SRef<CloudPoint>> pointCloud;
+		std::vector<Transform3Df> keyframePoses;
+		gMappingPipeline->getDataForVisualization(pointCloud, keyframePoses);
+		LOG_INFO("Number of cloud points: {}", pointCloud.size());
+		LOG_INFO("Number of keyframes: {}", keyframePoses.size());
+
 		gMappingPipeline->stop();
     }
     catch (xpcf::Exception & e) {

--- a/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi_conf.xml
+++ b/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi_conf.xml
@@ -252,7 +252,7 @@
 		<configure component="SolARDeviceDataLoader">
 			<property name="calibrationFile" type="string" value="../../data/data_hololens/hololens_calibration.yml"/>
 			<property name="pathToData" type="string" value="../../data/data_hololens/loop_desktop_A"/>
-			<property name="delayTime" type="int" value="500"/>
+			<property name="delayTime" type="int" value="300"/>
 		</configure>
 		<configure component="SolARImageViewerOpencv">
 			<property name="title" type="string" value="AR device mapping. Green = inliers, Red = outliers"/>

--- a/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi_conf.xml
+++ b/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi_conf.xml
@@ -278,7 +278,7 @@
 			<property name="minTrackedPoints" type="int" value="200"/>
 		</configure>
 		<configure component="SolARMapper">
-			<property name="directory" type="string" value="mapA"/>
+			<property name="directory" type="string" value="output/pipelinetest-multi-map"/>
 			<property name="identificationFileName" type="string" value="identification.bin"/>
 			<property name="coordinateFileName" type="string" value="coordinate.bin"/>
 			<property name="pointCloudManagerFileName" type="string" value="pointcloud.bin"/>

--- a/Mapping/SolARSample_Mapping_Mono/SolARSample_Mapping_Mono_conf.xml
+++ b/Mapping/SolARSample_Mapping_Mono/SolARSample_Mapping_Mono_conf.xml
@@ -240,7 +240,7 @@
 		<configure component="SolARDeviceDataLoader">
 			<property name="calibrationFile" type="string" value="../../data/data_hololens/hololens_calibration.yml"/>
 			<property name="pathToData" type="string" value="../../data/data_hololens/loop_desktop_A"/>
-			<property name="delayTime" type="int" value="1"/>
+			<property name="delayTime" type="int" value="300"/>
 		</configure>
 		<configure component="SolARSLAMBootstrapper">
 			<property name="hasPose" type="int" value="1"/>

--- a/Mapping/SolARSample_Mapping_Mono/SolARSample_Mapping_Mono_conf.xml
+++ b/Mapping/SolARSample_Mapping_Mono/SolARSample_Mapping_Mono_conf.xml
@@ -260,7 +260,7 @@
 			<property name="minTrackedPoints" type="int" value="200"/>
 		</configure>
 		<configure component="SolARMapper">
-			<property name="directory" type="string" value="mapA"/>
+			<property name="directory" type="string" value="output/sample-mono-map"/>
 			<property name="identificationFileName" type="string" value="identification.bin"/>
 			<property name="coordinateFileName" type="string" value="coordinate.bin"/>
 			<property name="pointCloudManagerFileName" type="string" value="pointcloud.bin"/>

--- a/Mapping/SolARSample_Mapping_Multi/SolARSample_Mapping_Multi_conf.xml
+++ b/Mapping/SolARSample_Mapping_Multi/SolARSample_Mapping_Multi_conf.xml
@@ -240,7 +240,7 @@
 		<configure component="SolARDeviceDataLoader">
 			<property name="calibrationFile" type="string" value="../../data/data_hololens/hololens_calibration.yml"/>
 			<property name="pathToData" type="string" value="../../data/data_hololens/loop_desktop_A"/>
-			<property name="delayTime" type="int" value="200"/>
+			<property name="delayTime" type="int" value="300"/>
 		</configure>
 		<configure component="SolARSLAMBootstrapper">
 			<property name="hasPose" type="int" value="1"/>

--- a/Mapping/SolARSample_Mapping_Multi/SolARSample_Mapping_Multi_conf.xml
+++ b/Mapping/SolARSample_Mapping_Multi/SolARSample_Mapping_Multi_conf.xml
@@ -260,7 +260,7 @@
 			<property name="minTrackedPoints" type="int" value="200"/>
 		</configure>
 		<configure component="SolARMapper">
-			<property name="directory" type="string" value="mapA"/>
+			<property name="directory" type="string" value="output/sample-multi-map"/>
 			<property name="identificationFileName" type="string" value="identification.bin"/>
 			<property name="coordinateFileName" type="string" value="coordinate.bin"/>
 			<property name="pointCloudManagerFileName" type="string" value="pointcloud.bin"/>


### PR DESCRIPTION
- Place maps produced by samples in bin, next to executables, in order to keep the data/ directory clean
- Give the same `delayTime` of SolARDeviceDataLoader for all samples
- Restore the info logs at the end of pipeline tests about the size of the point cloud and the number of Keyframes