### PR TITLE
fix: dependency on SolARFrameworkGRPCRemote

### DIFF
--- a/packagedependencies-linux.txt
+++ b/packagedependencies-linux.txt
@@ -1,1 +1,1 @@
-xpcfGrpcRemotingSolARFramework|0.10.0|xpcfGrpcRemotingSolARFramework|SolARBuild@github|https://github.com/SolarFramework/SolARFrameworkGRPCRemote/releases/download
+SolARFrameworkGRPCRemote|0.10.0|SolARFrameworkGRPCRemote|SolARBuild@github|https://github.com/SolarFramework/SolARFrameworkGRPCRemote/releases/download


### PR DESCRIPTION
Otherwise a 404 is returned when trying to remaken install:
https://github.com/SolarFramework/SolARFrameworkGRPCRemote/releases/tag/SolARFrameworkGRPCRemote%2F0.10.0%2Flinux
